### PR TITLE
Making image as display block

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -150,6 +150,7 @@ main, aside {
 
 img {
   max-width: 100%;
+  display: block;
 }
 
 .comment {


### PR DESCRIPTION
When an image is not square the author is showing on the left-hand side, making it as a display block will work as intended.

![image](https://user-images.githubusercontent.com/13746289/39617266-a98bfac2-4f9c-11e8-94cc-780a392552c0.png)

Will be shown as 

![image](https://user-images.githubusercontent.com/13746289/39617303-c91aee34-4f9c-11e8-89fe-b06340f43363.png)
